### PR TITLE
feat: Make portfolio responsive for mobile devices

### DIFF
--- a/style.css
+++ b/style.css
@@ -386,9 +386,50 @@ main {
 
 /* Responsive adjustments for About Me section */
 @media (max-width: 768px) {
+    main {
+        padding: 1rem 0.5rem; /* Reduce padding on mobile */
+    }
+
     #about .about-me-content {
         flex-direction: column;
         gap: 20px; /* Adjust gap for stacked layout */
+    }
+
+    /* --- Responsive Timeline --- */
+    #work-experience .timeline {
+        padding: 20px 10px;
+    }
+    #work-experience .timeline::before {
+        left: 20px;
+        transform: translateX(0);
+    }
+    #work-experience .timeline-item:nth-child(odd),
+    #work-experience .timeline-item:nth-child(even) {
+        width: 100%;
+        float: none;
+        text-align: left;
+        padding-left: 50px;
+        padding-right: 15px;
+        clear: both;
+    }
+    #work-experience .timeline-item:nth-child(odd) .timeline-marker,
+    #work-experience .timeline-item:nth-child(even) .timeline-marker {
+        left: 6px;
+    }
+    #work-experience .timeline-item:nth-child(odd) .timeline-dates,
+    #work-experience .timeline-item:nth-child(even) .timeline-dates {
+        position: relative;
+        left: 0;
+        right: auto;
+        top: -10px; /* Adjust position for flow */
+        text-align: left;
+        width: auto;
+        margin-bottom: 10px;
+        padding: 0;
+    }
+
+    #about .about-me-left p {
+        text-align: left;
     }
 }
 


### PR DESCRIPTION
Adds CSS media queries to `style.css` to ensure the portfolio layout adapts to smaller screens.

Key changes:
- A media query is added for screens up to 768px wide.
- The two-column "About Me" section now stacks vertically on mobile.
- The "Work Experience" timeline is converted from a two-sided, floated layout to a single-column, vertical layout on mobile.
- General padding and text alignment are adjusted for better readability on smaller devices.